### PR TITLE
fix: remove resize icon from the map

### DIFF
--- a/src/app/modules/page/dashboard/presentation/map/map.component.html
+++ b/src/app/modules/page/dashboard/presentation/map/map.component.html
@@ -18,8 +18,5 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <div class="map-container" [class.auto]="!this.mapData?.length">
-  <div class="map-resize" (click)="this.resize()">
-    <mat-icon>aspect_ratio</mat-icon>
-  </div>
   <div #map class="map-content"></div>
 </div>

--- a/src/app/modules/page/dashboard/presentation/map/map.component.ts
+++ b/src/app/modules/page/dashboard/presentation/map/map.component.ts
@@ -130,12 +130,6 @@ export class MapComponent implements AfterViewInit {
     return map;
   }
 
-  public resize(): void {
-    if (this.map) {
-      this.map.resize();
-    }
-  }
-
   private renderLayers(event: mapboxGl.MapboxEvent<unknown> & mapboxGl.EventData, data: PartsCoordinates[]) {
     const currentZoom = event.target.getZoom();
     const zoom = currentZoom > 4.5 ? 20 : 10;


### PR DESCRIPTION
Resize method adjust mapbox to it's container size. This shouldn't be available for the user, as this technical thing which we should invoke internally, if necessary . 