### PR TITLE
fix: part detail a11y

### DIFF
--- a/src/app/modules/shared/modules/part-details/presentation/part-detail.component.html
+++ b/src/app/modules/shared/modules/part-details/presentation/part-detail.component.html
@@ -112,7 +112,12 @@ SPDX-License-Identifier: Apache-2.0
   <div *ngIf="item.value" [class.card-list--row]="!this.showQualityTypeDropdown" class="card-list--qualityType">
     <ng-container *ngIf="!this.showQualityTypeDropdown">
       <p class="card-list--cell card-list--key">{{ 'partDetail.' + item.key | i18n }}</p>
-      <div (click)="this.showQualityTypeDropdown = true" class="card-list--cell card-list--value card-list--icon">
+      <div
+        (click)="this.showQualityTypeDropdown = true"
+        (keydown.enter)="this.showQualityTypeDropdown = true"
+        class="card-list--cell card-list--value card-list--icon"
+        tabindex="0"
+      >
         <app-quality-type [type]="selectedValue || item.value"></app-quality-type>
         <mat-icon class="ml-2" inline>edit</mat-icon>
       </div>
@@ -126,7 +131,13 @@ SPDX-License-Identifier: Apache-2.0
         [optionsRenderer]="qualityTypeOptionTmp"
         (selected)="this.updateQualityType($event)"
       ></app-select>
-      <mat-icon (click)="this.showQualityTypeDropdown = false" inline>close</mat-icon>
+      <mat-icon
+        (click)="this.showQualityTypeDropdown = false"
+        (keydown.enter)="this.showQualityTypeDropdown = false"
+        tabindex="0"
+        inline
+        >close</mat-icon
+      >
     </div>
   </div>
 </ng-template>


### PR DESCRIPTION
In general it's not a bug. A11y standards for the modal requires that in modal (sidenav is kind of modal) after it has been opened, focus receive first focusable element. However, first focusable element should be quality type dropdown and not zoom in.

In this PR I make quality type dropdown is keyboard friendly, which lead to changed autofocus behaviour.