### PR TITLE
fix: interpreting the date as -- when it is NULL in backend

### DIFF
--- a/src/app/modules/shared/pipes/format-date.pipe.spec.ts
+++ b/src/app/modules/shared/pipes/format-date.pipe.spec.ts
@@ -1,0 +1,34 @@
+/********************************************************************************
+ * Copyright (c) 2022, 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2022, 2023 ZF Friedrichshafen AG
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import { screen } from '@testing-library/angular';
+import { renderComponent } from '@tests/test-render.utils';
+import { SharedModule } from '..';
+
+describe('FormatDatePipe', () => {
+  it('should format date having the 1970 value for the year', async () => {
+    await renderComponent(`{{ 'unitTest.test01' | formatDate }}`, {
+      imports: [SharedModule],
+    });
+
+    expect(screen.getByText('This is for unit tests purposes.')).toBeInTheDocument();
+  });
+});

--- a/src/app/modules/shared/pipes/format-date.pipe.spec.ts
+++ b/src/app/modules/shared/pipes/format-date.pipe.spec.ts
@@ -19,16 +19,37 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import { CalendarDateModel } from '@core/model/calendar-date.model';
 import { screen } from '@testing-library/angular';
 import { renderComponent } from '@tests/test-render.utils';
 import { SharedModule } from '..';
 
 describe('FormatDatePipe', () => {
   it('should format date having the 1970 value for the year', async () => {
-    await renderComponent(`{{ 'unitTest.test01' | formatDate }}`, {
+    const date = new CalendarDateModel(null);
+    await renderComponent(`{{ date | formatDate }}`, {
+      imports: [SharedModule],
+      componentProperties: { date },
+    });
+
+    expect(screen.getByText('--')).toBeInTheDocument();
+  });
+
+  it('should format date without issues', async () => {
+    const date = new CalendarDateModel('2022-02-04T13:48:54Z');
+    await renderComponent(`{{ date | formatDate }}`, {
+      imports: [SharedModule],
+      componentProperties: { date },
+    });
+
+    expect(screen.getByText('2/4/2022')).toBeInTheDocument();
+  });
+
+  it('should return -- if string is empty', async () => {
+    await renderComponent(`{{ '' | formatDate }}`, {
       imports: [SharedModule],
     });
 
-    expect(screen.getByText('This is for unit tests purposes.')).toBeInTheDocument();
+    expect(screen.getByText('--')).toBeInTheDocument();
   });
 });

--- a/src/app/modules/shared/pipes/format-date.pipe.ts
+++ b/src/app/modules/shared/pipes/format-date.pipe.ts
@@ -52,6 +52,9 @@ export class FormatDatePipe implements PipeTransform, OnDestroy {
     }
 
     const date = typeof input === 'string' ? this.transformStringToDate(input) : input.valueOf();
+    if (date.getFullYear() == 1970) {
+      return '--';
+    }
     return this.dateFormat.format(date, this.formatOptions);
   }
 

--- a/src/app/modules/shared/pipes/format-date.pipe.ts
+++ b/src/app/modules/shared/pipes/format-date.pipe.ts
@@ -48,7 +48,7 @@ export class FormatDatePipe implements PipeTransform, OnDestroy {
 
   public transform(input: string | CalendarDateModel): string {
     if (!input) {
-      return '';
+      return '--';
     }
 
     const date = typeof input === 'string' ? this.transformStringToDate(input) : input.valueOf();


### PR DESCRIPTION
all NULL date values from the backend must be displayed as '--'